### PR TITLE
Smoothed yc

### DIFF
--- a/ykn.py
+++ b/ykn.py
@@ -110,13 +110,7 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
     gammacshat = get_gammahat(gamma_self, gammacs)
 
     nineshape = (9, len_t)
-    yc_shape = len_t
     Yc = zeros(nineshape)
-    Yc_valid = zeros(nineshape)
-    gammac = zeros(nineshape)
-    gammachat = zeros(nineshape)
-    Yc_rules = zeros(nineshape)
-    Yc_result = zeros(yc_shape)
 
     # Compute Yc in each functional regime.
     Yc[0] = YT
@@ -147,72 +141,32 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
     Yc[7] = inner_term ** (3 / 7)
     Yc[8] = inner_term
 
-    # For each Yc compute the corresponding gammac and gammachat
-    for i in arange(len(Yc)):
-        gammac[i] = gammacs / (1 + Yc[i])
-        gammachat[i] = get_gammahat(gamma_self, gammac[i])
-
-    # Yc_rules = 1 where each Yc obeys its own rules and = 0 where it does not.
-    Yc_rules[0] = (gammac[0] < gammam) & (gammac[0] < gammamhat)
-    Yc_rules[1] = (
-        (gammac[1] < gammam)
-        & (gammamhat < gammac[1])
-        & (gammac[1] < gammachat[1])
-        & (Yc[1] >= 1)
-    )
-    Yc_rules[2] = (
-        (gammac[2] < gammam)
-        & (gammamhat < gammac[2])
-        & (gammac[2] < gammachat[2])
-        & (Yc[2] < 1)
-    )
-    Yc_rules[3] = (gammac[3] < gammam) & (gammachat[3] < gammac[3])
-    Yc_rules[4] = (gammam < gammac[4]) & (gammac[4] < gammachat[4]) & (Yc[4] < 1)
-    Yc_rules[5] = (
-        (gammam < gammac[5])
-        & (gammachat[5] < gammac[5])
-        & (gammac[5] < gammamhat)
-        & (Yc[5] >= 1)
-    )
-    Yc_rules[6] = (
-        (gammam < gammac[6])
-        & (gammachat[6] < gammac[6])
-        & (gammac[6] < gammamhat)
-        & (Yc[6] < 1)
-    )
-    Yc_rules[7] = (
-        (gammam < gammac[7])
-        & (gammachat[7] < gammamhat)
-        & (gammamhat < gammac[7])
-        & (Yc[7] >= 1)
-    )
-    Yc_rules[8] = (
-        (gammam < gammac[8])
-        & (gammachat[8] < gammamhat)
-        & (gammamhat < gammac[8])
-        & (Yc[8] < 1)
-    )
-
-    for i in arange(9):
-        Yc_valid[i] = Yc[i] * Yc_rules[i]
+    # gammac, gammachat across all 9 regimes in two broadcast ops.
+    gammac    = gammacs / (1 + Yc)
+    gammachat = get_gammahat(gamma_self, gammac)
 
     # Smooth regime blending.
-    # The boolean Yc_rules above flip discretely at regime boundaries
-    # (and Yc[i] does not in general equal YT at the boundary), so the
-    # gap-fill `(Yc_result==0)*YT` joins discontinuously. That step is
-    # what propagates into every f_b(Yc) and shows up as a temporal kink
-    # in lightcurves. Replace the hard rule selection with a smooth
+    # The original code picked one Yc[i] per t with a discrete rule then
+    # filled gaps with YT; that gap-fill joined discontinuously because
+    # Yc[i] is not in general equal to YT at the regime boundary. The
+    # discontinuity propagates into every f_b(Yc) as a temporal kink in
+    # the lightcurve. Replace the hard rule selection with a smooth
     # indicator on each strict inequality:
     #     soft_lt(a, b) = 1 / (1 + (a / b)**s)   (~ 1{a < b})
-    # so each rule weight w[i] is a smooth product over its inequalities.
-    # YT fills any leftover weight (gap); a final soft-min with YT
-    # preserves the original Yc <= YT cap.
+    # so each regime weight w[i] is a smooth product over its
+    # inequalities. YT picks up any leftover weight; a final soft-min
+    # with YT preserves the original Yc <= YT cap.
+    #
+    # `(a/b)**5` is computed as r=a/b; r4=(r*r)**2; r4*r — three
+    # multiplications instead of NumPy's generic `**`, which is ~5x
+    # faster on big arrays and dominates yc_approx's runtime.
     from numpy import maximum
 
-    s_smooth = 5.0
-
     def _soft_lt(a, b):
-        return 1.0 / (1.0 + (a / b) ** s_smooth)
+        r = a / b
+        r2 = r * r
+        r4 = r2 * r2
+        return 1.0 / (1.0 + r4 * r)
 
     one = 1.0
     w_smooth = zeros(nineshape)
@@ -261,6 +215,49 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
         if dims == 2:
             return array([Yc_result for i in arange(len_q)]).transpose()
         return Yc_result
+
+    # debug path needs the hard-rule arrays for diagnostics
+    Yc_rules = zeros(nineshape)
+    Yc_rules[0] = (gammac[0] < gammam) & (gammac[0] < gammamhat)
+    Yc_rules[1] = (
+        (gammac[1] < gammam)
+        & (gammamhat < gammac[1])
+        & (gammac[1] < gammachat[1])
+        & (Yc[1] >= 1)
+    )
+    Yc_rules[2] = (
+        (gammac[2] < gammam)
+        & (gammamhat < gammac[2])
+        & (gammac[2] < gammachat[2])
+        & (Yc[2] < 1)
+    )
+    Yc_rules[3] = (gammac[3] < gammam) & (gammachat[3] < gammac[3])
+    Yc_rules[4] = (gammam < gammac[4]) & (gammac[4] < gammachat[4]) & (Yc[4] < 1)
+    Yc_rules[5] = (
+        (gammam < gammac[5])
+        & (gammachat[5] < gammac[5])
+        & (gammac[5] < gammamhat)
+        & (Yc[5] >= 1)
+    )
+    Yc_rules[6] = (
+        (gammam < gammac[6])
+        & (gammachat[6] < gammac[6])
+        & (gammac[6] < gammamhat)
+        & (Yc[6] < 1)
+    )
+    Yc_rules[7] = (
+        (gammam < gammac[7])
+        & (gammachat[7] < gammamhat)
+        & (gammamhat < gammac[7])
+        & (Yc[7] >= 1)
+    )
+    Yc_rules[8] = (
+        (gammam < gammac[8])
+        & (gammachat[8] < gammamhat)
+        & (gammamhat < gammac[8])
+        & (Yc[8] < 1)
+    )
+    Yc_valid = Yc * Yc_rules
 
     if debug == True:
         gammacvalid = zeros(shape=(9, len_t))

--- a/ykn.py
+++ b/ykn.py
@@ -150,11 +150,15 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
     # inequalities that define it. YT picks up any leftover weight; a
     # final soft-min with YT keeps Yc <= YT.
 
-    # Smoothing sharpness exponent. Matches `pl = 2` used by realspectra
-    # for the time-domain GS-regime blending and by knspectrum for KN
-    # sub-spectrum branch selection, so the same transition width applies
-    # everywhere a smoothed `a < b` shows up in the pipeline.
-    pl = 2
+    # Smoothing sharpness exponent. realspectra uses pl = 2 for the
+    # time-domain GS-regime blending and knspectrum uses the same for
+    # KN sub-spectrum branch selection. Here we use a sharper pl = 5
+    # because the 9 analytic Yc candidates can sit many orders of
+    # magnitude apart: a regime whose strict-< inequalities are only
+    # partially satisfied still leaks a non-trivial weight under pl = 2,
+    # and an off-regime Yc that's tiny then drags the weighted average
+    # away from YT. pl = 5 drops off-regime weights to ~10^-3.
+    pl = 5
 
     def _less_than(a, b):
         # Smooth indicator for `a < b`: ~1 when a << b, ~0 when a >> b,
@@ -195,6 +199,16 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
                    * _less_than(gammachat[8], gammamhat)
                    * _less_than(gammamhat, gammac[8])
                    * _less_than(Yc[8], one))
+
+    # Plausibility gate: a regime is only believed if its analytic
+    # Yc[i] value sits in the physically sensible range — positive,
+    # not many orders of magnitude above YT, not vanishingly small.
+    # Without this, a regime whose geometric ordering happens to hold
+    # by accident can fire with a nonsense Yc value (e.g. regime 3
+    # producing Yc ~ 1e-5 at t ~ 1e-6 d for some param sets) and pull
+    # the smoothed Yc result with it.
+    plausible = _less_than(Yc, 10.0 * YT) * _less_than(1e-3, Yc)
+    w_smooth = w_smooth * plausible
 
     # sum along axis 0 collapses the 9 regimes into per-t totals;
     # w_sum[t] is the total weight assigned at time t. Normalising by

--- a/ykn.py
+++ b/ykn.py
@@ -145,24 +145,20 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
     gammac    = gammacs / (1 + Yc)
     gammachat = get_gammahat(gamma_self, gammac)
 
-    # Smooth regime blending.
-    # The original code picked one Yc[i] per t with a discrete rule then
-    # filled gaps with YT; that gap-fill joined discontinuously because
-    # Yc[i] is not in general equal to YT at the regime boundary. The
-    # discontinuity propagates into every f_b(Yc) as a temporal kink in
-    # the lightcurve. Replace the hard rule selection with a smooth
-    # indicator on each strict inequality:
-    #     soft_lt(a, b) = 1 / (1 + (a / b)**s)   (~ 1{a < b})
-    # so each regime weight w[i] is a smooth product over its
-    # inequalities. YT picks up any leftover weight; a final soft-min
-    # with YT preserves the original Yc <= YT cap.
-    #
-    # `(a/b)**5` is computed as r=a/b; r4=(r*r)**2; r4*r — three
-    # multiplications instead of NumPy's generic `**`, which is ~5x
-    # faster on big arrays and dominates yc_approx's runtime.
+    # Combine the 9 candidate Yc values into a single Yc(t) by weighting
+    # each regime by the product of soft indicators on the strict
+    # inequalities that define it. YT picks up any leftover weight; a
+    # final soft-min with YT keeps Yc <= YT.
     from numpy import maximum
 
-    def _soft_lt(a, b):
+    def _less_than(a, b):
+        # Smooth indicator for `a < b`: ~1 when a << b, ~0 when a >> b,
+        # 0.5 at a = b. The functional form is 1 / (1 + (a/b)**5), with
+        # s = 5 setting how sharply the indicator transitions; this is
+        # the same sigmoid family Granot & Sari (2002) use to soften the
+        # break frequencies. Hardcoding the power as
+        #   r = a/b ; r^5 = (r * r)^2 * r
+        # is ~5x faster than NumPy's generic `**` on large arrays.
         r = a / b
         r2 = r * r
         r4 = r2 * r2
@@ -170,44 +166,55 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
 
     one = 1.0
     w_smooth = zeros(nineshape)
-    w_smooth[0] = (_soft_lt(gammac[0], gammam)
-                   * _soft_lt(gammac[0], gammamhat))
-    w_smooth[1] = (_soft_lt(gammac[1], gammam)
-                   * _soft_lt(gammamhat, gammac[1])
-                   * _soft_lt(gammac[1], gammachat[1])
-                   * _soft_lt(one, Yc[1]))
-    w_smooth[2] = (_soft_lt(gammac[2], gammam)
-                   * _soft_lt(gammamhat, gammac[2])
-                   * _soft_lt(gammac[2], gammachat[2])
-                   * _soft_lt(Yc[2], one))
-    w_smooth[3] = (_soft_lt(gammac[3], gammam)
-                   * _soft_lt(gammachat[3], gammac[3]))
-    w_smooth[4] = (_soft_lt(gammam, gammac[4])
-                   * _soft_lt(gammac[4], gammachat[4])
-                   * _soft_lt(Yc[4], one))
-    w_smooth[5] = (_soft_lt(gammam, gammac[5])
-                   * _soft_lt(gammachat[5], gammac[5])
-                   * _soft_lt(gammac[5], gammamhat)
-                   * _soft_lt(one, Yc[5]))
-    w_smooth[6] = (_soft_lt(gammam, gammac[6])
-                   * _soft_lt(gammachat[6], gammac[6])
-                   * _soft_lt(gammac[6], gammamhat)
-                   * _soft_lt(Yc[6], one))
-    w_smooth[7] = (_soft_lt(gammam, gammac[7])
-                   * _soft_lt(gammachat[7], gammamhat)
-                   * _soft_lt(gammamhat, gammac[7])
-                   * _soft_lt(one, Yc[7]))
-    w_smooth[8] = (_soft_lt(gammam, gammac[8])
-                   * _soft_lt(gammachat[8], gammamhat)
-                   * _soft_lt(gammamhat, gammac[8])
-                   * _soft_lt(Yc[8], one))
+    w_smooth[0] = (_less_than(gammac[0], gammam)
+                   * _less_than(gammac[0], gammamhat))
+    w_smooth[1] = (_less_than(gammac[1], gammam)
+                   * _less_than(gammamhat, gammac[1])
+                   * _less_than(gammac[1], gammachat[1])
+                   * _less_than(one, Yc[1]))
+    w_smooth[2] = (_less_than(gammac[2], gammam)
+                   * _less_than(gammamhat, gammac[2])
+                   * _less_than(gammac[2], gammachat[2])
+                   * _less_than(Yc[2], one))
+    w_smooth[3] = (_less_than(gammac[3], gammam)
+                   * _less_than(gammachat[3], gammac[3]))
+    w_smooth[4] = (_less_than(gammam, gammac[4])
+                   * _less_than(gammac[4], gammachat[4])
+                   * _less_than(Yc[4], one))
+    w_smooth[5] = (_less_than(gammam, gammac[5])
+                   * _less_than(gammachat[5], gammac[5])
+                   * _less_than(gammac[5], gammamhat)
+                   * _less_than(one, Yc[5]))
+    w_smooth[6] = (_less_than(gammam, gammac[6])
+                   * _less_than(gammachat[6], gammac[6])
+                   * _less_than(gammac[6], gammamhat)
+                   * _less_than(Yc[6], one))
+    w_smooth[7] = (_less_than(gammam, gammac[7])
+                   * _less_than(gammachat[7], gammamhat)
+                   * _less_than(gammamhat, gammac[7])
+                   * _less_than(one, Yc[7]))
+    w_smooth[8] = (_less_than(gammam, gammac[8])
+                   * _less_than(gammachat[8], gammamhat)
+                   * _less_than(gammamhat, gammac[8])
+                   * _less_than(Yc[8], one))
 
+    # sum along axis 0 collapses the 9 regimes into per-t totals.
+    # w_sum[t]   = total weight assigned to the 9 analytic regimes at time t.
+    # yt_weight  = the leftover, capped at 0 so it never goes negative when
+    #              the 9 regime weights slightly overshoot 1 near a boundary.
+    # denom normalises so a uniform shift in the weights doesn't bias Yc_result.
     w_sum = w_smooth.sum(axis=0)
     yt_weight = maximum(1.0 - w_sum, 0.0)
     denom = w_sum + yt_weight
     Yc_result = ((w_smooth * Yc).sum(axis=0) + yt_weight * YT) / denom
 
-    # Soft cap at YT (smooth replacement for `Yc_result[Yc_result>YT]=0`).
+    # Soft-min cap to enforce Yc <= YT. The combiner
+    #   (x^a + y^a)^(1/a)
+    # approaches min(x, y) for a -> -infinity and matches it everywhere
+    # outside a narrow window around x = y. a = -60/p^2 is the smoothing
+    # exponent Jacovich, Beniamini & van der Horst (JBH) Eq. 13 use to
+    # blend the fast- and slow-cooling YT branches; reusing it here keeps
+    # the cap's transition width consistent with the rest of yt().
     a_cap = -60.0 / p ** 2
     Yc_result = (Yc_result ** a_cap + YT ** a_cap) ** (1.0 / a_cap)
 

--- a/ykn.py
+++ b/ykn.py
@@ -195,14 +195,69 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
 
     for i in arange(9):
         Yc_valid[i] = Yc[i] * Yc_rules[i]
-        Yc_result = Yc_result + Yc_valid[i]
 
-    # Prevents any Yc > YT (otherwise this can occur over a small window due to
-    # slightly different normalization between ykn.yc_approx and ykn.yt).
-    Yc_result[Yc_result > YT] = 0
+    # Smooth regime blending.
+    # The boolean Yc_rules above flip discretely at regime boundaries
+    # (and Yc[i] does not in general equal YT at the boundary), so the
+    # gap-fill `(Yc_result==0)*YT` joins discontinuously. That step is
+    # what propagates into every f_b(Yc) and shows up as a temporal kink
+    # in lightcurves. Replace the hard rule selection with JBH-style
+    # smooth indicators on each strict inequality:
+    #     soft_lt(a, b) = sigmoid(s * log(b/a))   (~ 1{a < b})
+    # so each rule weight w[i] is a smooth product over its inequalities.
+    # YT fills any leftover weight (gap); a final soft-min with YT
+    # preserves the original Yc <= YT cap.
+    from numpy import tanh, log, clip, maximum
 
-    # Fills gaps between valid regions with Y Thomson.
-    Yc_result = Yc_result + (Yc_result == 0) * YT
+    s_smooth = 5.0
+
+    def _soft_lt(a, b):
+        delta = s_smooth * (log(clip(b, 1e-300, None))
+                            - log(clip(a, 1e-300, None)))
+        return 0.5 * (1.0 + tanh(0.5 * delta))
+
+    one = 1.0
+    w_smooth = zeros(nineshape)
+    w_smooth[0] = (_soft_lt(gammac[0], gammam)
+                   * _soft_lt(gammac[0], gammamhat))
+    w_smooth[1] = (_soft_lt(gammac[1], gammam)
+                   * _soft_lt(gammamhat, gammac[1])
+                   * _soft_lt(gammac[1], gammachat[1])
+                   * _soft_lt(one, Yc[1]))
+    w_smooth[2] = (_soft_lt(gammac[2], gammam)
+                   * _soft_lt(gammamhat, gammac[2])
+                   * _soft_lt(gammac[2], gammachat[2])
+                   * _soft_lt(Yc[2], one))
+    w_smooth[3] = (_soft_lt(gammac[3], gammam)
+                   * _soft_lt(gammachat[3], gammac[3]))
+    w_smooth[4] = (_soft_lt(gammam, gammac[4])
+                   * _soft_lt(gammac[4], gammachat[4])
+                   * _soft_lt(Yc[4], one))
+    w_smooth[5] = (_soft_lt(gammam, gammac[5])
+                   * _soft_lt(gammachat[5], gammac[5])
+                   * _soft_lt(gammac[5], gammamhat)
+                   * _soft_lt(one, Yc[5]))
+    w_smooth[6] = (_soft_lt(gammam, gammac[6])
+                   * _soft_lt(gammachat[6], gammac[6])
+                   * _soft_lt(gammac[6], gammamhat)
+                   * _soft_lt(Yc[6], one))
+    w_smooth[7] = (_soft_lt(gammam, gammac[7])
+                   * _soft_lt(gammachat[7], gammamhat)
+                   * _soft_lt(gammamhat, gammac[7])
+                   * _soft_lt(one, Yc[7]))
+    w_smooth[8] = (_soft_lt(gammam, gammac[8])
+                   * _soft_lt(gammachat[8], gammamhat)
+                   * _soft_lt(gammamhat, gammac[8])
+                   * _soft_lt(Yc[8], one))
+
+    w_sum = w_smooth.sum(axis=0)
+    yt_weight = maximum(1.0 - w_sum, 0.0)
+    denom = w_sum + yt_weight
+    Yc_result = ((w_smooth * Yc).sum(axis=0) + yt_weight * YT) / denom
+
+    # Soft cap at YT (smooth replacement for `Yc_result[Yc_result>YT]=0`).
+    a_cap = -60.0 / p ** 2
+    Yc_result = (Yc_result ** a_cap + YT ** a_cap) ** (1.0 / a_cap)
 
     if debug == False:
         if dims == 2:

--- a/ykn.py
+++ b/ykn.py
@@ -151,18 +151,19 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
     # final soft-min with YT keeps Yc <= YT.
     from numpy import maximum
 
+    # Smoothing sharpness exponent. Matches `pl = 2` used by realspectra
+    # for the time-domain GS-regime blending and by knspectrum for KN
+    # sub-spectrum branch selection, so the same transition width applies
+    # everywhere a smoothed `a < b` shows up in the pipeline.
+    pl = 2
+
     def _less_than(a, b):
         # Smooth indicator for `a < b`: ~1 when a << b, ~0 when a >> b,
-        # 0.5 at a = b. The functional form is 1 / (1 + (a/b)**5), with
-        # s = 5 setting how sharply the indicator transitions; this is
-        # the same sigmoid family Granot & Sari (2002) use to soften the
-        # break frequencies. Hardcoding the power as
-        #   r = a/b ; r^5 = (r * r)^2 * r
-        # is ~5x faster than NumPy's generic `**` on large arrays.
+        # 0.5 at a = b. The form 1 / (1 + (a/b)**pl) is the Granot &
+        # Sari (2002) sigmoid; with pl = 2 we hardcode the power as one
+        # multiplication (faster than NumPy's generic `**`).
         r = a / b
-        r2 = r * r
-        r4 = r2 * r2
-        return 1.0 / (1.0 + r4 * r)
+        return 1.0 / (1.0 + r * r)
 
     one = 1.0
     w_smooth = zeros(nineshape)

--- a/ykn.py
+++ b/ykn.py
@@ -149,7 +149,6 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
     # each regime by the product of soft indicators on the strict
     # inequalities that define it. YT picks up any leftover weight; a
     # final soft-min with YT keeps Yc <= YT.
-    from numpy import maximum
 
     # Smoothing sharpness exponent. Matches `pl = 2` used by realspectra
     # for the time-domain GS-regime blending and by knspectrum for KN
@@ -160,10 +159,8 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
     def _less_than(a, b):
         # Smooth indicator for `a < b`: ~1 when a << b, ~0 when a >> b,
         # 0.5 at a = b. The form 1 / (1 + (a/b)**pl) is the Granot &
-        # Sari (2002) sigmoid; with pl = 2 we hardcode the power as one
-        # multiplication (faster than NumPy's generic `**`).
-        r = a / b
-        return 1.0 / (1.0 + r * r)
+        # Sari (2002) sigmoid.
+        return 1.0 / (1.0 + (a / b) ** pl)
 
     one = 1.0
     w_smooth = zeros(nineshape)
@@ -199,15 +196,18 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
                    * _less_than(gammamhat, gammac[8])
                    * _less_than(Yc[8], one))
 
-    # sum along axis 0 collapses the 9 regimes into per-t totals.
-    # w_sum[t]   = total weight assigned to the 9 analytic regimes at time t.
-    # yt_weight  = the leftover, capped at 0 so it never goes negative when
-    #              the 9 regime weights slightly overshoot 1 near a boundary.
-    # denom normalises so a uniform shift in the weights doesn't bias Yc_result.
+    # sum along axis 0 collapses the 9 regimes into per-t totals;
+    # w_sum[t] is the total weight assigned at time t. Normalising by
+    # w_sum gives the regimes' weighted average Yc. YT is added only as
+    # a strict gap-filler — `gap` becomes ~1 only when w_sum drops to
+    # zero (no regime fits), so well-covered points get the regime
+    # average without YT bias. Without the gap test, a few percent of
+    # leftover weight times a huge YT would dominate the answer wherever
+    # YT >> Yc.
     w_sum = w_smooth.sum(axis=0)
-    yt_weight = maximum(1.0 - w_sum, 0.0)
-    denom = w_sum + yt_weight
-    Yc_result = ((w_smooth * Yc).sum(axis=0) + yt_weight * YT) / denom
+    gap = _less_than(w_sum, 0.01)
+    denom = w_sum + gap
+    Yc_result = ((w_smooth * Yc).sum(axis=0) + gap * YT) / denom
 
     # Soft-min cap to enforce Yc <= YT. The combiner
     #   (x^a + y^a)^(1/a)

--- a/ykn.py
+++ b/ykn.py
@@ -201,20 +201,18 @@ def yc_approx(params, gammam, gammacs, gamma_self, YT=None, debug=False):
     # (and Yc[i] does not in general equal YT at the boundary), so the
     # gap-fill `(Yc_result==0)*YT` joins discontinuously. That step is
     # what propagates into every f_b(Yc) and shows up as a temporal kink
-    # in lightcurves. Replace the hard rule selection with JBH-style
-    # smooth indicators on each strict inequality:
-    #     soft_lt(a, b) = sigmoid(s * log(b/a))   (~ 1{a < b})
+    # in lightcurves. Replace the hard rule selection with a smooth
+    # indicator on each strict inequality:
+    #     soft_lt(a, b) = 1 / (1 + (a / b)**s)   (~ 1{a < b})
     # so each rule weight w[i] is a smooth product over its inequalities.
     # YT fills any leftover weight (gap); a final soft-min with YT
     # preserves the original Yc <= YT cap.
-    from numpy import tanh, log, clip, maximum
+    from numpy import maximum
 
     s_smooth = 5.0
 
     def _soft_lt(a, b):
-        delta = s_smooth * (log(clip(b, 1e-300, None))
-                            - log(clip(a, 1e-300, None)))
-        return 0.5 * (1.0 + tanh(0.5 * delta))
+        return 1.0 / (1.0 + (a / b) ** s_smooth)
 
     one = 1.0
     w_smooth = zeros(nineshape)


### PR DESCRIPTION
Implement temporal smoothing in yc_approx by replacing the discrete Yc_rules selection (one of nine
   analytic regimes picked by strict-< orderings, YT fills the gap) with a smoothed weighted
  superposition over the nine regimes plus YT. Each rule's <, e.g. gammac[i] < gammam, is swapped for
   _less_than(a, b) = 1 / (1 + (a/b)**pl) (Granot & Sari) multiplied across the rule to give a soft
  weight in [0, 1]. YT only contributes through a gap = _less_than(w_sum, 0.01) term so it doesn't
  bias well-covered regions, and a JBH-Eq.13 soft-min with YT replaces the original
  Yc_result[Yc_result > YT] = 0 cap. Each weight is also gated by _less_than(Yc[i], 10*YT) *
  _less_than(1e-3, Yc[i]) so a rule whose geometric ordering holds by accident but whose Yc[i] is
  nonsense doesn't drag the answer with it. Uses pl = 5 rather than knspectrum's pl = 2 — at pl = 2
  an inactive regime still leaks ~10% weight which, times a wrong analytic Yc[i], swamps the average;
   pl = 5 drops leakage to ~10⁻³. Unlike the knspectrum diff this isn't equivalent to pre-diff
  behaviour for any flag — the smoothing changes the answer by design — but yc_approx is ~2% of total
   lightcurve time so end-to-end runtime stays within ±5% of master, see
  https://github.com/georgeamccarthy/ykn_temporal_smoothing/blob/main/scripts/bench_yc_approx.py.
  Effect of swapping just the ykn smoothing on top of a fixed GAMMA is in
  https://github.com/georgeamccarthy/ykn_temporal_smoothing/blob/main/notebook.py.